### PR TITLE
Remove CleverReach from prepopulation link generator

### DIFF
--- a/src/data/prepopulation-link/emailMarketingTokens.ts
+++ b/src/data/prepopulation-link/emailMarketingTokens.ts
@@ -1,8 +1,4 @@
-export type EmailMarketingProviders =
-	| "Mailchimp"
-	| "DotDigital"
-	| "CleverReach"
-	| "Other";
+export type EmailMarketingProviders = "Mailchimp" | "DotDigital" | "Other";
 
 export type EmailMarketingProviderFields =
 	| "title"
@@ -28,7 +24,6 @@ type Tokens = {
 export const emailMarketingProviders: EmailMarketingProviders[] = [
 	"Mailchimp",
 	"DotDigital",
-	"CleverReach",
 	"Other",
 ];
 
@@ -39,67 +34,56 @@ export const emailMarketingTokens: EmailMarketingTokens = {
 	title: {
 		Mailchimp: "",
 		DotDigital: "",
-		CleverReach: "{TITLE}",
 		Other: "",
 	},
 	first_name: {
 		Mailchimp: "*|FNAME|*",
 		DotDigital: "@FIRSTNAME@",
-		CleverReach: "{FIRSTNAME}",
 		Other: "",
 	},
 	last_name: {
 		Mailchimp: "*|LNAME|*",
 		DotDigital: "@LASTNAME@",
-		CleverReach: "{LASTNAME}",
 		Other: "",
 	},
 	email: {
 		Mailchimp: "*|EMAIL|*",
 		DotDigital: "@EMAIL@",
-		CleverReach: "{EMAIL}",
 		Other: "",
 	},
 	phone_number: {
 		Mailchimp: "*|PHONE|*",
 		DotDigital: "@PHONE@",
-		CleverReach: "",
 		Other: "",
 	},
 	mobile_number: {
 		Mailchimp: "*|PHONE|*",
 		DotDigital: "@PHONE@",
-		CleverReach: "",
 		Other: "",
 	},
 	street_address: {
 		Mailchimp: "",
 		DotDigital: "@ADDRESS@",
-		CleverReach: "{STREET}",
 		Other: "",
 	},
 	city: {
 		Mailchimp: "",
 		DotDigital: "@CITY@",
-		CleverReach: "{CITY}",
 		Other: "",
 	},
 	state: {
 		Mailchimp: "",
 		DotDigital: "@STATE@",
-		CleverReach: "",
 		Other: "",
 	},
 	postcode: {
 		Mailchimp: "",
 		DotDigital: "@ZIP@",
-		CleverReach: "{ZIP}",
 		Other: "",
 	},
 	country: {
 		Mailchimp: "",
 		DotDigital: "@COUNTRY@",
-		CleverReach: "{COUNTRY}",
 		Other: "",
 	},
 };
@@ -120,9 +104,5 @@ export const emailMarketingTokenDocumentation: EmailMarketingTokenDocumentationT
 		DotDigital: {
 			tokenTerminology: "Data field",
 			link: "https://support.dotdigital.com/en/articles/8198875-add-data-field-personalisation-to-your-email-campaign-or-landing-page",
-		},
-		CleverReach: {
-			tokenTerminology: "Variable",
-			link: "https://support.cleverreach.de/hc/en-us/articles/360020682999-Newsletter-Editor-Personalize-Texts",
 		},
 	};

--- a/src/pages/prepopulation-link.astro
+++ b/src/pages/prepopulation-link.astro
@@ -16,7 +16,7 @@ import Feedback from "@/components/Feedback.astro";
         href="https://support.impact-stack.org/hc/en-us/articles/115001868166-How-to-pre-populate-forms-from-email-URLs"
         >prepopulate Impact Stack form fields</a
       > with the data you already have about them in your Mailchimp, Dotdigital,
-      CleverReach or other email tool.
+      or other email tool.
     </p>
   </div>
 

--- a/tests/prepopulation-link.spec.ts
+++ b/tests/prepopulation-link.spec.ts
@@ -30,12 +30,6 @@ test.describe('Prepopulation Link Generator', () => {
     await expect(page.getByText('@FIRSTNAME@')).toBeVisible();
     await expect(page.getByText('@LASTNAME@')).toBeVisible();
     await expect(page.getByText('@EMAIL@')).toBeVisible();
-    
-    // Switch to CleverReach
-    await page.getByRole('button', { name: 'CleverReach' }).first().click();
-    await expect(page.getByText('{firstname}')).toBeVisible();
-    await expect(page.getByText('{lastname}')).toBeVisible();
-    await expect(page.getByText('{email}')).toBeVisible();
   });
 
   test('should handle donation interval dropdown', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Drop CleverReach as a supported email marketing provider in the prepopulation link generator (type, provider list, token mappings, and documentation link).
- Update the tool description text and tests to match.

## Test plan
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm test prepopulation-link` — all tests pass